### PR TITLE
add simulated camera launch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ sudo apt install git-lfs \
     ros-$ROS_DISTRO-rviz-2d-overlay-msgs \
     ros-$ROS_DISTRO-rosbag2 \
     ros-$ROS_DISTRO-plotjuggler-ros \
+    gstreamer1.0-plugins-base \
     libgstreamer1.0-dev \
     libgstreamer-plugins-base1.0-dev
 ```
@@ -100,6 +101,80 @@ Hardware-in-the-loop:
 ros2 launch ros2_control_blue_reach_5 robot_system_multi_interface.launch.py \
     use_manipulator_hardware:=true \
     use_vehicle_hardware:=true
+```
+
+The main launch file uses `serial_port:=auto` by default for the Reach Alpha manipulator. Auto mode tries `/dev/serial/by-id/*`, `/dev/ttyUSB*`, then `/dev/ttyACM*`. If the manipulator is on a known device, pass it explicitly:
+
+```bash
+ros2 launch ros2_control_blue_reach_5 robot_system_multi_interface.launch.py \
+    use_manipulator_hardware:=true \
+    use_vehicle_hardware:=false \
+    serial_port:=/dev/ttyUSB1
+```
+
+## Camera
+
+The camera is an independent GStreamer node. It is not owned by the vehicle hardware interface.
+
+Camera launch arguments:
+
+- `launch_camera:=auto`: default. Starts the camera when `use_vehicle_hardware:=true` or `simulate_camera:=true`.
+- `launch_camera:=true`: always starts the camera node.
+- `launch_camera:=false`: disables the camera node.
+- `simulate_camera:=false`: default. Uses the hardware UDP camera pipeline.
+- `simulate_camera:=true`: uses a synthetic GStreamer test pattern and publishes it as `/alpha/image_raw`.
+- `camera_pipeline:=""`: optional custom GStreamer pipeline. If set, it overrides the default pipeline. The pipeline must end with `appsink name=camera_sink`.
+
+Real vehicle hardware starts the camera automatically:
+
+```bash
+ros2 launch ros2_control_blue_reach_5 robot_system_multi_interface.launch.py \
+    use_vehicle_hardware:=true
+```
+
+Use the real camera without real vehicle hardware:
+
+```bash
+ros2 launch ros2_control_blue_reach_5 robot_system_multi_interface.launch.py \
+    use_manipulator_hardware:=true \
+    use_vehicle_hardware:=false \
+    sim_robot_count:=0 \
+    task:=manual \
+    launch_camera:=true
+```
+
+Simulate the camera when no camera hardware is connected:
+
+```bash
+ros2 launch ros2_control_blue_reach_5 robot_system_multi_interface.launch.py \
+    use_manipulator_hardware:=true \
+    use_vehicle_hardware:=false \
+    sim_robot_count:=0 \
+    task:=manual \
+    simulate_camera:=true
+```
+
+The camera publishes `sensor_msgs/msg/Image` on `/alpha/image_raw`. RViz adds an enabled `video feed` Image display whenever the camera node is launched. To verify images are arriving:
+
+```bash
+ros2 topic hz /alpha/image_raw
+```
+
+Run only the standalone camera node:
+
+```bash
+ros2 run ros2_control_blue_reach_5 gstreamer_camera_node --ros-args \
+    -p image_topic:=/alpha/image_raw \
+    -p frame_id:=camera_link
+```
+
+Run only the standalone simulated camera:
+
+```bash
+ros2 run ros2_control_blue_reach_5 gstreamer_camera_node --ros-args \
+    -p image_topic:=/alpha/image_raw \
+    -p frame_id:=camera_link \
+    -p pipeline:='videotestsrc is-live=true pattern=ball ! video/x-raw,width=640,height=480,framerate=30/1 ! videoconvert ! video/x-raw,format=(string)BGR ! appsink name=camera_sink emit-signals=true sync=false async=false max-buffers=1 drop=true'
 ```
 
 ## Reset

--- a/bringup/launch/robot_system_multi_interface.launch.py
+++ b/bringup/launch/robot_system_multi_interface.launch.py
@@ -65,6 +65,24 @@ def _resolve_serial_port(serial_port: str, use_manipulator_hardware: bool) -> st
     return fallback_port
 
 
+def _parse_bool_arg(name: str, value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"true", "1", "yes", "on"}:
+        return True
+    if normalized in {"false", "0", "no", "off"}:
+        return False
+    raise RuntimeError(f"{name} must be one of: true, false.")
+
+
+def _simulated_camera_pipeline() -> str:
+    return (
+        "videotestsrc is-live=true pattern=ball "
+        "! video/x-raw,width=640,height=480,framerate=30/1 "
+        "! videoconvert ! video/x-raw,format=(string)BGR "
+        "! appsink name=camera_sink emit-signals=true sync=false async=false max-buffers=1 drop=true"
+    )
+
+
 def generate_launch_description():
     # Declare arguments
     declared_arguments = []
@@ -109,6 +127,20 @@ def generate_launch_description():
             "launch_camera",
             default_value="auto",
             description="Start the independent GStreamer camera node. Use true, false, or auto. auto follows use_vehicle_hardware.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "simulate_camera",
+            default_value="false",
+            description="Use a synthetic GStreamer test camera instead of the UDP hardware camera.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "camera_pipeline",
+            default_value="",
+            description="Optional custom GStreamer pipeline. Must end with appsink name=camera_sink.",
         )
     )
 
@@ -215,6 +247,8 @@ def launch_setup(context, *args, **kwargs):
     use_manipulator_hardware = LaunchConfiguration("use_manipulator_hardware").perform(context)
     use_vehicle_hardware = LaunchConfiguration("use_vehicle_hardware").perform(context)
     launch_camera = LaunchConfiguration("launch_camera").perform(context)
+    simulate_camera = LaunchConfiguration("simulate_camera").perform(context)
+    camera_pipeline = LaunchConfiguration("camera_pipeline").perform(context)
     task = LaunchConfiguration("task").perform(context)
     serial_port = LaunchConfiguration("serial_port").perform(context)
     state_update_frequency = LaunchConfiguration("state_update_frequency").perform(context)
@@ -304,15 +338,19 @@ def launch_setup(context, *args, **kwargs):
 
     use_mocap_bool = IfCondition(use_mocap).evaluate(context)
     launch_planner_action_server_bool = IfCondition(launch_planner_action_server).evaluate(context)
+    simulate_camera_bool = _parse_bool_arg("simulate_camera", simulate_camera)
     launch_camera_normalized = launch_camera.strip().lower()
     if launch_camera_normalized == "auto":
-        launch_camera_bool = use_vehicle_hardware_bool
+        launch_camera_bool = use_vehicle_hardware_bool or simulate_camera_bool
     elif launch_camera_normalized in {"true", "1", "yes", "on"}:
         launch_camera_bool = True
     elif launch_camera_normalized in {"false", "0", "no", "off"}:
         launch_camera_bool = False
     else:
         raise RuntimeError("launch_camera must be one of: auto, true, false.")
+    camera_pipeline = camera_pipeline.strip()
+    if not camera_pipeline and simulate_camera_bool:
+        camera_pipeline = _simulated_camera_pipeline()
 
     is_hardware_uvms = use_manipulator_hardware_bool and use_vehicle_hardware_bool
 
@@ -494,6 +532,7 @@ def launch_setup(context, *args, **kwargs):
         parameters=[{
             "image_topic": "/alpha/image_raw",
             "frame_id": f"{camera_prefix}camera_link",
+            **({"pipeline": camera_pipeline} if camera_pipeline else {}),
         }],
     )
 


### PR DESCRIPTION
## Summary

- Add `simulate_camera` and `camera_pipeline` launch arguments for the independent GStreamer camera node.
- Make `launch_camera:=auto` start the camera when simulated camera mode is enabled.
- Document camera modes, standalone camera commands, and `serial_port:=auto` behavior in the README.

## Why

The camera interface is now independent from vehicle hardware, but users also need a no-hardware path for RViz testing and development. Simulated camera mode publishes a synthetic GStreamer image stream on `/alpha/image_raw` so RViz can display camera output without UDP camera hardware.

## Validation

- `python3 -m py_compile bringup/launch/robot_system_multi_interface.launch.py bringup/utils/rviz_utils.py`
- `colcon build --packages-select ros2_control_blue_reach_5 --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- Smoke-tested `simulate_camera:=true` launch and verified `/alpha/image_raw` published frames with `ros2 topic hz /alpha/image_raw`.