### PR TITLE
clean hardware interface shutdown

### DIFF
--- a/bringup/sim_reset_coordinator.py
+++ b/bringup/sim_reset_coordinator.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 import rclpy
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.executors import MultiThreadedExecutor
+from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
 from rclpy.node import Node
 from std_srvs.srv import Trigger
 
@@ -145,10 +145,16 @@ def main() -> None:
 
     try:
         executor.spin()
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    except Exception:
+        if rclpy.ok():
+            raise
     finally:
         executor.shutdown()
         node.destroy_node()
-        rclpy.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/hardware/bluerov_system_multi_interface.cpp
+++ b/hardware/bluerov_system_multi_interface.cpp
@@ -1505,18 +1505,7 @@ namespace ros2_control_blue_reach_5
 
     ros2_control_blue_reach_5::BlueRovSystemMultiInterfaceHardware::~BlueRovSystemMultiInterfaceHardware()
     {
-        dvl_driver_.stop();
-
-        if (executor_)
-        {
-            executor_->cancel();
-        }
-        if (spin_thread_.joinable())
-        {
-            spin_thread_.join();
-        }
-        RCLCPP_INFO(rclcpp::get_logger("BlueRovSystemMultiInterfaceHardware"),
-                    "Executor stopped and spin thread joined.");
+        stop_background_work();
     }
 
     void BlueRovSystemMultiInterfaceHardware::stop_thrusters()
@@ -1534,7 +1523,26 @@ namespace ros2_control_blue_reach_5
     hardware_interface::CallbackReturn BlueRovSystemMultiInterfaceHardware::on_cleanup(
         const rclcpp_lifecycle::State & /*previous_state*/)
     {
-        dvl_driver_.stop();
+        stop_background_work();
+        tfListener_.reset();
+        tfBuffer_.reset();
+        RCLCPP_INFO(rclcpp::get_logger("BlueRovSystemMultiInterfaceHardware"),
+                    "Cleaned up executor and spin thread.");
+        return hardware_interface::CallbackReturn::SUCCESS;
+    }
+
+    void BlueRovSystemMultiInterfaceHardware::stop_background_work() noexcept
+    {
+        try
+        {
+            dvl_driver_.stop();
+        }
+        catch (const std::exception &e)
+        {
+            RCLCPP_WARN(
+                rclcpp::get_logger("BlueRovSystemMultiInterfaceHardware"),
+                "Exception while stopping DVL driver: %s", e.what());
+        }
 
         if (executor_)
         {
@@ -1544,13 +1552,8 @@ namespace ros2_control_blue_reach_5
         {
             spin_thread_.join();
         }
-        tfListener_.reset();
-        tfBuffer_.reset();
         node_topics_interface_.reset();
         executor_.reset();
-        RCLCPP_INFO(rclcpp::get_logger("BlueRovSystemMultiInterfaceHardware"),
-                    "Cleaned up executor and spin thread.");
-        return hardware_interface::CallbackReturn::SUCCESS;
     }
 
 } // namespace ros2_control_blue_reach_5

--- a/hardware/include/ros2_control_blue_reach_5/bluerov_system_multi_interface.hpp
+++ b/hardware/include/ros2_control_blue_reach_5/bluerov_system_multi_interface.hpp
@@ -77,7 +77,7 @@ namespace ros2_control_blue_reach_5
     {
 
     public:
-        ~BlueRovSystemMultiInterfaceHardware();
+        ~BlueRovSystemMultiInterfaceHardware() override;
         RCLCPP_SHARED_PTR_DEFINITIONS(BlueRovSystemMultiInterfaceHardware);
 
         ROS2_CONTROL_BLUE_REACH_5_PUBLIC
@@ -125,6 +125,7 @@ namespace ros2_control_blue_reach_5
             const rclcpp::Time &time, const rclcpp::Duration &period) override;
 
     private:
+        void stop_background_work() noexcept;
         void light_callback(const std_msgs::msg::Float32::SharedPtr msg);
         void cameraMountPitch_callback(const std_msgs::msg::Float32::SharedPtr msg);
         rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr light_subscriber_;

--- a/hardware/include/ros2_control_blue_reach_5/reach_system_multi_Interface.hpp
+++ b/hardware/include/ros2_control_blue_reach_5/reach_system_multi_Interface.hpp
@@ -71,6 +71,9 @@ namespace ros2_control_blue_reach_5
     RCLCPP_SHARED_PTR_DEFINITIONS(ReachSystemMultiInterfaceHardware);
 
     ROS2_CONTROL_BLUE_REACH_5_PUBLIC
+    ~ReachSystemMultiInterfaceHardware() override;
+
+    ROS2_CONTROL_BLUE_REACH_5_PUBLIC
     hardware_interface::CallbackReturn on_init(
         const hardware_interface::HardwareComponentInterfaceParams &params) override;
 
@@ -203,11 +206,13 @@ namespace ros2_control_blue_reach_5
      */
 
     void pollState(int freq) const;
+    void stop_background_work() noexcept;
 
     // Driver things
     alpha::driver::Driver driver_;
     std::thread state_request_worker_;
     std::atomic<bool> running_{false};
+    bool driver_started_{false};
 
     std::mutex access_async_states_;
 

--- a/hardware/include/ros2_control_blue_reach_5/sim_reach_system_multi_interface.hpp
+++ b/hardware/include/ros2_control_blue_reach_5/sim_reach_system_multi_interface.hpp
@@ -59,6 +59,9 @@ namespace ros2_control_blue_reach_5
         RCLCPP_SHARED_PTR_DEFINITIONS(SimReachSystemMultiInterfaceHardware);
 
         ROS2_CONTROL_BLUE_REACH_5_PUBLIC
+        ~SimReachSystemMultiInterfaceHardware() override;
+
+        ROS2_CONTROL_BLUE_REACH_5_PUBLIC
         hardware_interface::CallbackReturn on_init(
             const hardware_interface::HardwareComponentInterfaceParams &params) override;
 
@@ -105,6 +108,7 @@ namespace ros2_control_blue_reach_5
     private:
         void reset_joint_simulation_state();
         void reset_joint_estimators();
+        void stop_ros_interfaces() noexcept;
 
         double payload_mass = 0;
         double payload_Ixx = 0;

--- a/hardware/include/ros2_control_blue_reach_5/sim_vehicle_system_multi_interface.hpp
+++ b/hardware/include/ros2_control_blue_reach_5/sim_vehicle_system_multi_interface.hpp
@@ -65,6 +65,9 @@ namespace ros2_control_blue_reach_5
         RCLCPP_SHARED_PTR_DEFINITIONS(SimVehicleSystemMultiInterfaceHardware);
 
         ROS2_CONTROL_BLUE_REACH_5_PUBLIC
+        ~SimVehicleSystemMultiInterfaceHardware() override;
+
+        ROS2_CONTROL_BLUE_REACH_5_PUBLIC
         hardware_interface::CallbackReturn on_init(
             const hardware_interface::HardwareComponentInterfaceParams &params) override;
 
@@ -72,9 +75,9 @@ namespace ros2_control_blue_reach_5
         hardware_interface::CallbackReturn on_configure(
             const rclcpp_lifecycle::State &previous_state) override;
 
-        // ROS2_CONTROL_BLUE_REACH_5_PUBLIC
-        // hardware_interface::CallbackReturn on_cleanup(
-        //     const rclcpp_lifecycle::State &previous_state) override;
+        ROS2_CONTROL_BLUE_REACH_5_PUBLIC
+        hardware_interface::CallbackReturn on_cleanup(
+            const rclcpp_lifecycle::State &previous_state) override;
 
         ROS2_CONTROL_BLUE_REACH_5_PUBLIC
         hardware_interface::return_type prepare_command_mode_switch(
@@ -111,6 +114,7 @@ namespace ros2_control_blue_reach_5
     private:
         void reset_vehicle_simulation_state();
         void reset_vehicle_estimators();
+        void stop_ros_interfaces() noexcept;
 
         // Store the utils function for the robot joints
         casadi_reach_alpha_5::Utils utils_service;

--- a/hardware/reach_system_multi_Interface.cpp
+++ b/hardware/reach_system_multi_Interface.cpp
@@ -34,6 +34,11 @@ using namespace casadi;
 
 namespace ros2_control_blue_reach_5
 {
+  ReachSystemMultiInterfaceHardware::~ReachSystemMultiInterfaceHardware()
+  {
+    stop_background_work();
+  }
+
   hardware_interface::CallbackReturn ReachSystemMultiInterfaceHardware::on_init(
       const hardware_interface::HardwareComponentInterfaceParams &params)
   {
@@ -147,6 +152,7 @@ namespace ros2_control_blue_reach_5
     try
     {
       driver_.start(cfg_.serial_port_);
+      driver_started_ = true;
     }
     catch (const std::exception &e)
     {
@@ -199,6 +205,7 @@ namespace ros2_control_blue_reach_5
     {
       RCLCPP_ERROR(rclcpp::get_logger("SimReachSystemMultiInterfaceHardware"),
                    "Failed TF publisher setup, %s", e.what());
+      stop_background_work();
       return hardware_interface::CallbackReturn::ERROR;
     }
     RCLCPP_INFO( // NOLINT
@@ -248,20 +255,7 @@ namespace ros2_control_blue_reach_5
     RCLCPP_INFO( // NOLINT
         rclcpp::get_logger("ReachSystemMultiInterfaceHardware"), "Shutting down the AlphaHardware system interface.");
 
-    running_.store(false);
-    state_request_worker_.join();
-    driver_.stop();
-
-    if (executor_)
-    {
-      executor_->cancel();
-    }
-    if (spin_thread_.joinable())
-    {
-      spin_thread_.join();
-    }
-    executor_.reset();
-    node_frames_interface_.reset();
+    stop_background_work();
     return hardware_interface::CallbackReturn::SUCCESS;
   }
 
@@ -848,6 +842,42 @@ namespace ros2_control_blue_reach_5
 
       std::this_thread::sleep_for(poll_period);
     }
+  }
+
+  void ReachSystemMultiInterfaceHardware::stop_background_work() noexcept
+  {
+    running_.store(false);
+
+    if (state_request_worker_.joinable())
+    {
+      state_request_worker_.join();
+    }
+
+    if (driver_started_)
+    {
+      try
+      {
+        driver_.stop();
+      }
+      catch (const std::exception &e)
+      {
+        RCLCPP_WARN(
+            rclcpp::get_logger("ReachSystemMultiInterfaceHardware"),
+            "Exception while stopping Reach serial driver: %s", e.what());
+      }
+      driver_started_ = false;
+    }
+
+    if (executor_)
+    {
+      executor_->cancel();
+    }
+    if (spin_thread_.joinable())
+    {
+      spin_thread_.join();
+    }
+    executor_.reset();
+    node_frames_interface_.reset();
   }
 
 } // namespace ros2_control_blue_reach_5

--- a/hardware/sim_reach_system_multi_interface.cpp
+++ b/hardware/sim_reach_system_multi_interface.cpp
@@ -29,6 +29,11 @@ using namespace casadi;
 
 namespace ros2_control_blue_reach_5
 {
+    SimReachSystemMultiInterfaceHardware::~SimReachSystemMultiInterfaceHardware()
+    {
+        stop_ros_interfaces();
+    }
+
     void SimReachSystemMultiInterfaceHardware::reset_joint_estimators()
     {
         const std::size_t nj = get_hardware_info().joints.size();
@@ -116,6 +121,22 @@ namespace ros2_control_blue_reach_5
             rclcpp::get_logger("SimReachSystemMultiInterfaceHardware"),
             "[%s] reset simulated manipulator state for %zu joints; commands held until release",
             robot_prefix.c_str(), joint_count);
+    }
+
+    void SimReachSystemMultiInterfaceHardware::stop_ros_interfaces() noexcept
+    {
+        if (executor_)
+        {
+            executor_->cancel();
+        }
+        if (spin_thread_.joinable())
+        {
+            spin_thread_.join();
+        }
+        reset_service_.reset();
+        release_service_.reset();
+        executor_.reset();
+        node_frames_interface_.reset();
     }
 
     hardware_interface::CallbackReturn SimReachSystemMultiInterfaceHardware::on_init(
@@ -309,16 +330,7 @@ namespace ros2_control_blue_reach_5
 
     hardware_interface::CallbackReturn SimReachSystemMultiInterfaceHardware::on_cleanup(const rclcpp_lifecycle::State &)
     {
-        if (executor_)
-        {
-            executor_->cancel();
-        }
-        if (spin_thread_.joinable())
-        {
-            spin_thread_.join();
-        }
-        executor_.reset();
-        node_frames_interface_.reset();
+        stop_ros_interfaces();
         RCLCPP_INFO( // NOLINT
             rclcpp::get_logger("SimReachSystemMultiInterfaceHardware"), "Shutting down the AlphaHardware system interface.");
         return hardware_interface::CallbackReturn::SUCCESS;

--- a/hardware/sim_vehicle_system_multi_interface.cpp
+++ b/hardware/sim_vehicle_system_multi_interface.cpp
@@ -36,6 +36,11 @@ using namespace casadi;
 
 namespace ros2_control_blue_reach_5
 {
+    SimVehicleSystemMultiInterfaceHardware::~SimVehicleSystemMultiInterfaceHardware()
+    {
+        stop_ros_interfaces();
+    }
+
     void SimVehicleSystemMultiInterfaceHardware::reset_vehicle_estimators()
     {
         x_est_ = casadi::DM::zeros(18, 1);
@@ -83,6 +88,23 @@ namespace ros2_control_blue_reach_5
             "[%s] reset simulated vehicle state for %zu thrusters; commands held until release",
             hw_vehicle_struct.robot_prefix.c_str(),
             hw_vehicle_struct.hw_thrust_structs_.size());
+    }
+
+    void SimVehicleSystemMultiInterfaceHardware::stop_ros_interfaces() noexcept
+    {
+        if (executor_)
+        {
+            executor_->cancel();
+        }
+        if (spin_thread_.joinable())
+        {
+            spin_thread_.join();
+        }
+        reset_service_.reset();
+        release_service_.reset();
+        static_tf_broadcaster_.reset();
+        executor_.reset();
+        node_topics_interface_.reset();
     }
 
     hardware_interface::CallbackReturn SimVehicleSystemMultiInterfaceHardware::on_init(
@@ -387,6 +409,15 @@ namespace ros2_control_blue_reach_5
                     "Initialized P_est_, Q_, and R_ for Kalman filter.");
         RCLCPP_INFO(
             rclcpp::get_logger("SimVehicleSystemMultiInterfaceHardware"), "configure successful");
+        return hardware_interface::CallbackReturn::SUCCESS;
+    }
+
+    hardware_interface::CallbackReturn SimVehicleSystemMultiInterfaceHardware::on_cleanup(const rclcpp_lifecycle::State &)
+    {
+        stop_ros_interfaces();
+        RCLCPP_INFO(
+            rclcpp::get_logger("SimVehicleSystemMultiInterfaceHardware"),
+            "Shutting down the simulated vehicle system interface.");
         return hardware_interface::CallbackReturn::SUCCESS;
     }
 


### PR DESCRIPTION
## Summary

- Add destructor-backed cleanup for the real Reach hardware interface so polling and executor threads are stopped before object destruction.
- Make the real Reach cleanup path idempotent and guarded against unstarted driver/thread state.
- Add matching destructor cleanup for simulated Reach and simulated vehicle hardware interfaces so their ROS executor threads are not left joinable on shutdown.
- Normalize real vehicle cleanup behind the same destructor-safe helper so DVL shutdown, executor cancellation, spin-thread join, and ROS interface reset are shared by destructor and `on_cleanup()`.
- Guard the simulated reset coordinator against Ctrl-C and repeated rclpy shutdown during launch teardown.

## Why

Ctrl-C shutdown can deactivate and shut down ros2_control hardware without calling each component's `on_cleanup()` before destruction. The real Reach interface could therefore reach the implicit `std::thread` destructor with `state_request_worker_` still joinable, causing `std::terminate` and an aborted `ros2_control_node`.

Vehicle interfaces also own background work: real vehicle owns a DVL driver and executor spin thread, while simulated vehicle owns an executor spin thread. Keeping the destructor and lifecycle cleanup paths consistent prevents the same class of shutdown issue there.

The reset coordinator also needed to tolerate launch shutdown after the rclpy context is already invalidated so it does not add a Python traceback during Ctrl-C.

## Validation

- `python3 -m py_compile bringup/sim_reset_coordinator.py`
- `python3 -m py_compile simlab/shutdown.py simlab/voxel_viz.py simlab/env_obstacles.py simlab/collision_contact.py simlab/planner_action_server.py simlab/use_mocap.py simlab/interactive_control.py simlab/joystick_control.py`
- `colcon build --packages-select ros2_control_blue_reach_5 simlab --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- Ran a simulated multi-interface launch with `timeout --signal=INT` and confirmed the previous `~thread`/`std::terminate` abort and Python shutdown tracebacks are gone.

Remaining shutdown noise in the forced timeout run is ROS launch SIGINT process-status reporting and the ROS 2 `controller_manager.pal_statistics` message from controller manager internals.