### PR TITLE
fix robot state TF ownership

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,11 @@ install(TARGETS gstreamer_camera_node
 )
 
 install(PROGRAMS
+  bringup/robot_description_publisher.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(PROGRAMS
   bringup/sim_camera_renderer.py
   DESTINATION lib/${PROJECT_NAME}
   RENAME sim_camera_renderer_node

--- a/bringup/launch/robot_system_multi_interface.launch.py
+++ b/bringup/launch/robot_system_multi_interface.launch.py
@@ -560,11 +560,75 @@ def launch_setup(context, *args, **kwargs):
         output="screen",
     )
 
+    world_state_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("ros2_control_blue_reach_5"),
+                    "xacro",
+                    "robot_state_publisher_world.urdf.xacro",
+                ]
+            ),
+            " ",
+            "world_frame:=",
+            world_frame,
+        ]
+    )
+
+    robot_state_pub_nodes = [
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            name=f"robot_state_publisher_{robot_prefix.rstrip('_')}",
+            output="both",
+            remappings=[
+                ("robot_description", f"{robot_prefix.rstrip('_')}/robot_description"),
+            ],
+            parameters=[{
+                "publish_robot_description": False,
+                "robot_description": Command(
+                    [
+                        PathJoinSubstitution([FindExecutable(name="xacro")]),
+                        " ",
+                        PathJoinSubstitution(
+                            [
+                                FindPackageShare("ros2_control_blue_reach_5"),
+                                "xacro",
+                                "robot_state_publisher_robot.urdf.xacro",
+                            ]
+                        ),
+                        " ",
+                        "prefix:=",
+                        robot_prefix,
+                    ]
+                )
+            }],
+        )
+        for robot_prefix in robot_prefixes
+    ]
+
     # Nodes Definitions
-    robot_state_pub_node = Node(
+    world_state_pub_node = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
+        name="robot_state_publisher_world",
         output="both",
+        remappings=[
+            ("robot_description", "robot_state_publisher_world/robot_description"),
+        ],
+        parameters=[{
+            "publish_robot_description": False,
+            "robot_description": world_state_description_content,
+        }],
+    )
+
+    robot_description_pub_node = Node(
+        package="ros2_control_blue_reach_5",
+        executable="robot_description_publisher.py",
+        name="robot_description_publisher",
+        output="screen",
         parameters=[robot_description],
     )
 
@@ -852,10 +916,12 @@ def launch_setup(context, *args, **kwargs):
     simulator_actions = [
         reset_coordinator_proc,
         joint_state_broadcaster_spawner,
+        robot_description_pub_node,
         control_node,
         mode,
         run_plotjuggler,
-        robot_state_pub_node,
+        world_state_pub_node,
+        *robot_state_pub_nodes,
         all_spawners[0],
         *chain_handlers,
         switch_after_all,

--- a/bringup/robot_description_publisher.py
+++ b/bringup/robot_description_publisher.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+from std_msgs.msg import String
+
+
+class RobotDescriptionPublisher(Node):
+    def __init__(self):
+        super().__init__("robot_description_publisher")
+        self.declare_parameter("robot_description", "")
+        self._description = self.get_parameter("robot_description").value
+        if not self._description:
+            raise RuntimeError("robot_description parameter must not be empty")
+
+        qos = QoSProfile(depth=1)
+        qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+        qos.reliability = ReliabilityPolicy.RELIABLE
+        self._publisher = self.create_publisher(String, "robot_description", qos)
+        self._timer = self.create_timer(5.0, self._publish)
+        self._publish()
+
+    def _publish(self):
+        msg = String()
+        msg.data = self._description
+        self._publisher.publish(msg)
+
+
+def main():
+    rclpy.init()
+    node = RobotDescriptionPublisher()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/description/xacro/robot_state_publisher_robot.urdf.xacro
+++ b/description/xacro/robot_state_publisher_robot.urdf.xacro
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="alpha_5_robot_state_publisher_robot">
+
+  <xacro:arg name="description_package" default="ros2_control_blue_reach_5"/>
+  <xacro:arg name="robot_name" default="dory"/>
+  <xacro:arg name="prefix" default="robot_1_"/>
+
+  <xacro:property name="description_package" value="$(arg description_package)"/>
+  <xacro:property name="robot_name" value="$(arg robot_name)"/>
+  <xacro:property name="prefix" value="$(arg prefix)"/>
+
+  <xacro:include filename="$(find ${description_package})/xacro/urdf.xacro"/>
+
+  <!--
+    TF-only robot description.
+    The vehicle hardware interface owns the global map->base_link transform, so
+    this tree is rooted at ${prefix}base_link and publishes only local robot links.
+  -->
+  <xacro:bluerov2_heavy_alpha_urdf
+    robot_name="${robot_name}"
+    prefix="${prefix}"
+    attach_to_world="false"/>
+
+</robot>

--- a/description/xacro/robot_state_publisher_world.urdf.xacro
+++ b/description/xacro/robot_state_publisher_world.urdf.xacro
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="alpha_5_robot_state_publisher_world">
+
+  <xacro:arg name="description_package" default="ros2_control_blue_reach_5"/>
+  <xacro:arg name="world_frame" default="world"/>
+
+  <xacro:property name="description_package" value="$(arg description_package)"/>
+  <xacro:property name="world_frame" value="$(arg world_frame)"/>
+
+  <xacro:include filename="$(find ${description_package})/xacro/world.xacro"/>
+
+  <!-- Environment/static world tree. Robot global base transforms are published by the vehicle interfaces. -->
+  <xacro:sim_world world_frame="${world_frame}"/>
+
+</robot>

--- a/description/xacro/urdf.xacro
+++ b/description/xacro/urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="bluerov2_heavy_alpha_urdf" params="robot_name prefix x:=0.0 y:=0.0 z:=2.0 rot_r:=0.0 rot_p:=0.0 rot_y:=0.0">
+  <xacro:macro name="bluerov2_heavy_alpha_urdf" params="robot_name prefix x:=0.0 y:=0.0 z:=2.0 rot_r:=0.0 rot_p:=0.0 rot_y:=0.0 attach_to_world:=true">
 
     <link name="${prefix}manipulator_mount_link">
       <visual>
@@ -63,12 +63,13 @@
       </collision>
     </link>
 
-      
-    <joint name="${prefix}base_joint" type="fixed">
-      <child link="${prefix}base_link" />
-      <parent link="base_link" />
-      <origin xyz="${x} ${y} ${z}" rpy="${rot_r} ${rot_p} ${rot_y}"/>
-    </joint>
+    <xacro:if value="${attach_to_world}">
+      <joint name="${prefix}base_joint" type="fixed">
+        <child link="${prefix}base_link" />
+        <parent link="base_link" />
+        <origin xyz="${x} ${y} ${z}" rpy="${rot_r} ${rot_p} ${rot_y}"/>
+      </joint>
+    </xacro:if>
 
     <joint name="${prefix}manipulator_mount_joint" type="fixed">
       <origin rpy="0 0 0" xyz="0.19 0.0 -0.12" />
@@ -99,4 +100,3 @@
 </robot>
   <!-- Used for fixing robot -->
  
-

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
   <depend>realtime_tools</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>nav2_msgs</depend>


### PR DESCRIPTION
Cleans up TF ownership in the multi-robot launch pipeline.

Changes:
- keep the full control URDF for ros2_control_node and /robot_description
- publish world/environment frames separately
- launch one robot-local robot_state_publisher per simulated robot
- keep robot_N_map -> robot_N_base_link owned by the vehicle interface

This is a TF correctness cleanup. It is not a complete fix for the remaining manipulator visualization jitter.

Verification:
- python3 -m py_compile bringup/launch/robot_system_multi_interface.launch.py bringup/robot_description_publisher.py
- colcon build --packages-select ros2_control_blue_reach_5